### PR TITLE
fix: 修复包引用版本兼容问题并升级为3.1

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -12,7 +12,7 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Create Release
         id: create_release
         uses: actions/create-release@v1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -13,7 +13,7 @@ jobs:
     strategy:
       matrix:
         os: [ ubuntu-latest ]
-        php-version: [ '8.0', '8.1' ]
+        php-version: [ '8.1', '8.2' ]
         engine: [ 'none', 'swoole', 'swow' ]
       max-parallel: 5
       fail-fast: false

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -19,7 +19,7 @@ jobs:
       fail-fast: false
     steps:
       - name: Checkout
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Setup PHP
         uses: shivammathur/setup-php@v2
         with:

--- a/.php-cs-fixer.php
+++ b/.php-cs-fixer.php
@@ -80,6 +80,7 @@ return (new PhpCsFixer\Config())
         'single_quote' => true,
         'standardize_not_equals' => true,
         'multiline_comment_opening_closing' => true,
+        'single_line_empty_body' => false,
     ])
     ->setFinder(
         PhpCsFixer\Finder::create()

--- a/composer.json
+++ b/composer.json
@@ -18,14 +18,16 @@
         }
     },
     "require": {
-        "php": ">=7.3",
+        "php": ">=8.1",
         "aliyuncs/oss-sdk-php": "^2.4",
-        "hyperf/utils": "^2.2|^3.0",
+        "hyperf/support": "~3.1.0",
         "league/flysystem": "^2.1|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "hyperf/di": "^2.2",
+        "hyperf/codec": "~3.1",
+        "hyperf/context": "~3.1",
+        "hyperf/di": "~3.1",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan": "^0.12",
         "phpunit/phpunit": ">=7.0",

--- a/composer.json
+++ b/composer.json
@@ -21,6 +21,7 @@
         "php": ">=8.1",
         "aliyuncs/oss-sdk-php": "^2.4",
         "hyperf/support": "~3.1.0",
+        "jetbrains/phpstorm-attributes": "^1.0",
         "league/flysystem": "^2.1|^3.0"
     },
     "require-dev": {

--- a/composer.json
+++ b/composer.json
@@ -20,15 +20,15 @@
     "require": {
         "php": ">=8.1",
         "aliyuncs/oss-sdk-php": "^2.4",
-        "hyperf/support": "~3.1.0",
+        "hyperf/support": "^3.1",
         "jetbrains/phpstorm-attributes": "^1.0",
         "league/flysystem": "^2.1|^3.0"
     },
     "require-dev": {
         "friendsofphp/php-cs-fixer": "^3.0",
-        "hyperf/codec": "~3.1",
-        "hyperf/context": "~3.1",
-        "hyperf/di": "~3.1",
+        "hyperf/codec": "^3.1",
+        "hyperf/context": "^3.1",
+        "hyperf/di": "^3.1",
         "mockery/mockery": "^1.0",
         "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": ">=7.0",

--- a/composer.json
+++ b/composer.json
@@ -30,7 +30,7 @@
         "hyperf/context": "~3.1",
         "hyperf/di": "~3.1",
         "mockery/mockery": "^1.0",
-        "phpstan/phpstan": "^0.12",
+        "phpstan/phpstan": "^1.0",
         "phpunit/phpunit": ">=7.0",
         "swoole/ide-helper": "dev-master",
         "swow/swow": "dev-develop",

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -13,6 +13,7 @@ declare(strict_types=1);
 namespace Hyperf\Flysystem\OSS;
 
 use Hyperf\Support\ResourceGenerator;
+use JetBrains\PhpStorm\ArrayShape;
 use League\Flysystem\Config;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;
@@ -31,19 +32,17 @@ class Adapter implements FilesystemAdapter
      */
     protected $bucket;
 
-    /**
-     * @param $config = [
-     *               'accessId' => '',
-     *               'accessSecret' => '',
-     *               'bucket' => '',
-     *               'endpoint' => '',
-     *               'timeout' => 3600,
-     *               'connectTimeout' => 10,
-     *               'isCName' => false,
-     *               'token' => '',
-     *               'proxy' => null,
-     *               ]
-     */
+    #[ArrayShape([
+        'accessId' => 'string',
+        'accessSecret' => 'string',
+        'bucket' => 'string',
+        'endpoint' => 'string',
+        'timeout' => 'int',
+        'connectTimeout' => 'int',
+        'isCName' => 'bool',
+        'token' => 'string',
+        'proxy' => 'mixed',
+    ])]
     public function __construct($config = [])
     {
         $this->bucket = $config['bucket'];

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace Hyperf\Flysystem\OSS;
 
 use Hyperf\Support\ResourceGenerator;
@@ -32,16 +33,16 @@ class Adapter implements FilesystemAdapter
 
     /**
      * @param $config = [
-     *     'accessId' => '',
-     *     'accessSecret' => '',
-     *     'bucket' => '',
-     *     'endpoint' => '',
-     *     'timeout' => 3600,
-     *     'connectTimeout' => 10,
-     *     'isCName' => false,
-     *     'token' => '',
-     *     'proxy' => null,
-     * ]
+     *               'accessId' => '',
+     *               'accessSecret' => '',
+     *               'bucket' => '',
+     *               'endpoint' => '',
+     *               'timeout' => 3600,
+     *               'connectTimeout' => 10,
+     *               'isCName' => false,
+     *               'token' => '',
+     *               'proxy' => null,
+     *               ]
      */
     public function __construct($config = [])
     {

--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -11,7 +11,7 @@ declare(strict_types=1);
  */
 namespace Hyperf\Flysystem\OSS;
 
-use Hyperf\Utils\ResourceGenerator;
+use Hyperf\Support\ResourceGenerator;
 use League\Flysystem\Config;
 use League\Flysystem\FileAttributes;
 use League\Flysystem\FilesystemAdapter;

--- a/src/ConfigProvider.php
+++ b/src/ConfigProvider.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace Hyperf\Flysystem\OSS;
 
 class ConfigProvider

--- a/tests/Cases/AbstractTestCase.php
+++ b/tests/Cases/AbstractTestCase.php
@@ -9,6 +9,7 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace HyperfTest\Cases;
 
 use PHPUnit\Framework\TestCase;

--- a/tests/Cases/OssAdapterTest.php
+++ b/tests/Cases/OssAdapterTest.php
@@ -9,15 +9,15 @@ declare(strict_types=1);
  * @contact  group@hyperf.io
  * @license  https://github.com/hyperf/hyperf/blob/master/LICENSE
  */
+
 namespace HyperfTest\Cases;
 
+use Hyperf\Codec\Json;
 use Hyperf\Context\ApplicationContext;
 use Hyperf\Di\Container;
 use Hyperf\Flysystem\OSS\Adapter;
-use Hyperf\Codec\Json;
 use Hyperf\Support\ResourceGenerator;
 use League\Flysystem\Filesystem;
-use Mockery;
 use OSS\OssClient;
 
 /**
@@ -30,13 +30,13 @@ class OssAdapterTest extends AbstractTestCase
 
     protected function tearDown(): void
     {
-        Mockery::close();
+        \Mockery::close();
     }
 
     public function testWrite()
     {
         $container = $this->getContainer();
-        $container->shouldReceive('make')->with(OssClient::class, Mockery::any())->andReturnUsing(function ($_, $args) {
+        $container->shouldReceive('make')->with(OssClient::class, \Mockery::any())->andReturnUsing(function ($_, $args) {
             $client = $this->getDefaultOssClient();
             $client->shouldReceive('putObject')->withAnyArgs()->once()->andReturnNull();
             return $client;
@@ -49,7 +49,7 @@ class OssAdapterTest extends AbstractTestCase
     public function testFileExists()
     {
         $container = $this->getContainer();
-        $container->shouldReceive('make')->with(OssClient::class, Mockery::any())->andReturnUsing(function ($_, $args) {
+        $container->shouldReceive('make')->with(OssClient::class, \Mockery::any())->andReturnUsing(function ($_, $args) {
             $client = $this->getDefaultOssClient();
             $client->shouldReceive('doesObjectExist')->with($this->bucket, 'test.json')->once()->andReturnTrue();
             return $client;
@@ -62,7 +62,7 @@ class OssAdapterTest extends AbstractTestCase
     public function testWriteStream()
     {
         $container = $this->getContainer();
-        $container->shouldReceive('make')->with(OssClient::class, Mockery::any())->andReturnUsing(function ($_, $args) {
+        $container->shouldReceive('make')->with(OssClient::class, \Mockery::any())->andReturnUsing(function ($_, $args) {
             $client = $this->getDefaultOssClient();
             $client->shouldReceive('appendObject')->withAnyArgs()->once()->andReturnNull();
             return $client;
@@ -75,7 +75,7 @@ class OssAdapterTest extends AbstractTestCase
     public function testGetObject()
     {
         $container = $this->getContainer();
-        $container->shouldReceive('make')->with(OssClient::class, Mockery::any())->andReturnUsing(function ($_, $args) {
+        $container->shouldReceive('make')->with(OssClient::class, \Mockery::any())->andReturnUsing(function ($_, $args) {
             $client = $this->getDefaultOssClient();
             $client->shouldReceive('getObject')->with($this->bucket, 'test.json')->once()->andReturn('{}');
             return $client;
@@ -88,7 +88,7 @@ class OssAdapterTest extends AbstractTestCase
     public function testDelete()
     {
         $container = $this->getContainer();
-        $container->shouldReceive('make')->with(OssClient::class, Mockery::any())->andReturnUsing(function ($_, $args) {
+        $container->shouldReceive('make')->with(OssClient::class, \Mockery::any())->andReturnUsing(function ($_, $args) {
             $client = $this->getDefaultOssClient();
             $client->shouldReceive('deleteObject')->with($this->bucket, 'test.json')->once()->andReturnNull();
             return $client;
@@ -101,8 +101,8 @@ class OssAdapterTest extends AbstractTestCase
     public function testSetTimeout()
     {
         $container = $this->getContainer();
-        $container->shouldReceive('make')->with(OssClient::class, Mockery::any())->andReturnUsing(function ($_, $args) {
-            $client = Mockery::mock(OssClient::class);
+        $container->shouldReceive('make')->with(OssClient::class, \Mockery::any())->andReturnUsing(function ($_, $args) {
+            $client = \Mockery::mock(OssClient::class);
             $client->shouldReceive('setTimeout')->with(3600)->once()->andReturnNull();
             $client->shouldReceive('setConnectTimeout')->with(10)->once()->andReturnNull();
             return $client;
@@ -111,8 +111,8 @@ class OssAdapterTest extends AbstractTestCase
         new Filesystem($adapter);
 
         $container = $this->getContainer();
-        $container->shouldReceive('make')->with(OssClient::class, Mockery::any())->andReturnUsing(function ($_, $args) {
-            $client = Mockery::mock(OssClient::class);
+        $container->shouldReceive('make')->with(OssClient::class, \Mockery::any())->andReturnUsing(function ($_, $args) {
+            $client = \Mockery::mock(OssClient::class);
             $client->shouldReceive('setTimeout')->with(1000)->once()->andReturnNull();
             $client->shouldReceive('setConnectTimeout')->with(20)->once()->andReturnNull();
             return $client;
@@ -131,7 +131,7 @@ class OssAdapterTest extends AbstractTestCase
 
     protected function getDefaultOssClient()
     {
-        $client = Mockery::mock(OssClient::class);
+        $client = \Mockery::mock(OssClient::class);
         $client->shouldReceive('setTimeout')->with(3600)->andReturnNull();
         $client->shouldReceive('setConnectTimeout')->with(10)->andReturnNull();
         return $client;
@@ -149,7 +149,7 @@ class OssAdapterTest extends AbstractTestCase
 
     protected function getContainer()
     {
-        $container = Mockery::mock(Container::class);
+        $container = \Mockery::mock(Container::class);
         ApplicationContext::setContainer($container);
         return $container;
     }

--- a/tests/Cases/OssAdapterTest.php
+++ b/tests/Cases/OssAdapterTest.php
@@ -11,11 +11,11 @@ declare(strict_types=1);
  */
 namespace HyperfTest\Cases;
 
+use Hyperf\Context\ApplicationContext;
 use Hyperf\Di\Container;
 use Hyperf\Flysystem\OSS\Adapter;
-use Hyperf\Utils\ApplicationContext;
-use Hyperf\Utils\Codec\Json;
-use Hyperf\Utils\ResourceGenerator;
+use Hyperf\Codec\Json;
+use Hyperf\Support\ResourceGenerator;
 use League\Flysystem\Filesystem;
 use Mockery;
 use OSS\OssClient;

--- a/tests/Cases/OssAdapterTest.php
+++ b/tests/Cases/OssAdapterTest.php
@@ -43,7 +43,8 @@ class OssAdapterTest extends AbstractTestCase
         });
         $adapter = new Adapter($this->getDefaultOptions());
         $flysystem = new Filesystem($adapter);
-        $this->assertNull($flysystem->write('test.json', Json::encode(['id' => uniqid()])));
+        $flysystem->write('test.json', Json::encode(['id' => uniqid()]));
+        $this->assertTrue(true);
     }
 
     public function testFileExists()
@@ -69,7 +70,8 @@ class OssAdapterTest extends AbstractTestCase
         });
         $adapter = new Adapter($this->getDefaultOptions());
         $flysystem = new Filesystem($adapter);
-        $this->assertNull($flysystem->writeStream('test3.json', ResourceGenerator::from(Json::encode(['name' => uniqid()]))));
+        $flysystem->writeStream('test3.json', ResourceGenerator::from(Json::encode(['name' => uniqid()])));
+        $this->assertTrue(true);
     }
 
     public function testGetObject()
@@ -95,7 +97,8 @@ class OssAdapterTest extends AbstractTestCase
         });
         $adapter = new Adapter($this->getDefaultOptions());
         $flysystem = new Filesystem($adapter);
-        $this->assertNull($flysystem->delete('test.json'));
+        $flysystem->delete('test.json');
+        $this->assertTrue(true);
     }
 
     public function testSetTimeout()


### PR DESCRIPTION
issue：https://github.com/hyperf/hyperf/issues/6589

在3.1中由于utils包改动，导致部分引用类缺失。

本次调整如下：
1. 移除`hyperf/utils`包
2. 新增`hyperf/support`包替代`hyperf/utils`
3. 调整单测中的引用失败的包。