### PR TITLE
feat: Support non-GET temporaryUrl

### DIFF
--- a/src/Adapter.php
+++ b/src/Adapter.php
@@ -72,7 +72,7 @@ class Adapter implements FilesystemAdapter, TemporaryUrlGenerator
     public function temporaryUrl(string $path, \DateTimeInterface $expiresAt, Config $config): string
     {
         $timeout = $expiresAt->getTimestamp() - time();
-        return $this->client->signUrl($this->bucket, $path, $timeout, OssClient::OSS_HTTP_GET, $config->toArray());
+        return $this->client->signUrl($this->bucket, $path, $timeout, $config->get('method', OssClient::OSS_HTTP_GET), $config->toArray());
     }
 
     public function directoryExists(string $path): bool


### PR DESCRIPTION
在开发中有时候需要直接生成PUT方式的鉴权链接，供客户端直接上传文件到oss，hyperf当前写死了GET